### PR TITLE
Fixed platforms to disappear when fully to the left of the screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Start a local http server to play:
 npm run start
 ```
 
-
 Open [`127.0.0.1:8080/src/index.html`](http://127.0.0.1:8080/src/index.html) to start playing!
 
 ### Contribution Guidelines

--- a/src/scenes/game.js
+++ b/src/scenes/game.js
@@ -116,7 +116,7 @@ export default class GameScene extends Phaser.Scene {
   }
 
   updatePlatforms(platform) {
-    if (platform.x < 0) {
+    if (platform.x < platform.width) {
       let randDiff = Math.floor(Math.random() * 250);
       platform.x = options.windowWidth + randDiff;
     } else {


### PR DESCRIPTION
Fixes #21. Platforms should disappear when their `x` is less than their `width`. Waiting only until `0` means they disappear immediately upon hitting the left bound of the game.