### PR TITLE
Kl add pause shortcut

### DIFF
--- a/src/scenes/game.js
+++ b/src/scenes/game.js
@@ -8,6 +8,7 @@ let highscore;
 let scoreText;
 let isPaused = false;
 let pauseButton;
+let pKey;
 
 export default class GameScene extends Phaser.Scene {
     constructor() {
@@ -78,6 +79,9 @@ export default class GameScene extends Phaser.Scene {
             fontSize: options.mediumFontSize,
             fill: options.blackText,
         });
+
+        // create p key input
+        pKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.P);
 
         // add pause button with text
         pauseButton = this.add.rectangle(
@@ -150,6 +154,20 @@ export default class GameScene extends Phaser.Scene {
                 });
             }
             this.platforms.children.iterate(this.updatePlatforms, this);
+        }
+        if (Phaser.Input.Keyboard.JustDown(pKey)) {
+            if (isPaused) {
+                pauseButton.text.setText("(P)ause");
+                pauseButton.text.x += 6;
+                this.physics.resume();
+                this.anims.resumeAll();
+            } else {
+                pauseButton.text.setText("un(P)ause");
+                pauseButton.text.x -= 6;
+                this.physics.pause();
+                this.anims.pauseAll();
+            }
+            isPaused = !isPaused;
         }
     }
 

--- a/src/scenes/game.js
+++ b/src/scenes/game.js
@@ -100,18 +100,7 @@ export default class GameScene extends Phaser.Scene {
         });
 
         pauseButton.on("pointerup", () => {
-            if (isPaused) {
-                pauseButton.text.setText("(P)ause");
-                pauseButton.text.x += 6;
-                this.physics.resume();
-                this.anims.resumeAll();
-            } else {
-                pauseButton.text.setText("un(P)ause");
-                pauseButton.text.x -= 6;
-                this.physics.pause();
-                this.anims.pauseAll();
-            }
-            isPaused = !isPaused;
+            this.togglePause();
         });
     }
 
@@ -156,19 +145,23 @@ export default class GameScene extends Phaser.Scene {
             this.platforms.children.iterate(this.updatePlatforms, this);
         }
         if (Phaser.Input.Keyboard.JustDown(pKey)) {
-            if (isPaused) {
-                pauseButton.text.setText("(P)ause");
-                pauseButton.text.x += 6;
-                this.physics.resume();
-                this.anims.resumeAll();
-            } else {
-                pauseButton.text.setText("un(P)ause");
-                pauseButton.text.x -= 6;
-                this.physics.pause();
-                this.anims.pauseAll();
-            }
-            isPaused = !isPaused;
+            this.togglePause();
         }
+    }
+
+    togglePause() {
+        if (isPaused) {
+            pauseButton.text.setText("(P)ause");
+            pauseButton.text.x += 6;
+            this.physics.resume();
+            this.anims.resumeAll();
+        } else {
+            pauseButton.text.setText("un(P)ause");
+            pauseButton.text.x -= 6;
+            this.physics.pause();
+            this.anims.pauseAll();
+        }
+        isPaused = !isPaused;
     }
 
     updatePlatforms(platform) {

--- a/src/scenes/game.js
+++ b/src/scenes/game.js
@@ -7,6 +7,7 @@ let score;
 let highscore;
 let scoreText;
 let isPaused = false;
+let pauseButton;
 
 export default class GameScene extends Phaser.Scene {
     constructor() {
@@ -79,30 +80,30 @@ export default class GameScene extends Phaser.Scene {
         });
 
         // add pause button with text
-        const togglePause = this.add.rectangle(
-            this.game.config.width,
+        pauseButton = this.add.rectangle(
+            this.game.config.width - 70,
             25,
-            150,
+            100,
             30,
             options.purpleBox,
         );
-        togglePause.setInteractive();
+        pauseButton.setInteractive();
 
-        togglePause.text = this.add.text(this.game.config.width - 60, 14, "pause", {
+        pauseButton.text = this.add.text(this.game.config.width - 100, 14, "(P)ause", {
             fontFamily: options.fontFamily,
             fontSize: options.smallFontSize,
             fill: options.whiteText,
         });
 
-        togglePause.on("pointerup", () => {
+        pauseButton.on("pointerup", () => {
             if (isPaused) {
-                togglePause.text.setText("pause");
-                togglePause.text.x += 3;
+                pauseButton.text.setText("(P)ause");
+                pauseButton.text.x += 6;
                 this.physics.resume();
                 this.anims.resumeAll();
             } else {
-                togglePause.text.setText("resume");
-                togglePause.text.x -= 3;
+                pauseButton.text.setText("un(P)ause");
+                pauseButton.text.x -= 6;
                 this.physics.pause();
                 this.anims.pauseAll();
             }


### PR DESCRIPTION
fixes #63 

I could not underline as Phaser doesn't support that - workaround would have been:
+ importing a separate phaser library to do so (not that I've tried but seems a bit over kill).
+ adding parens around the P in "pause" -> "(P)ause" 

I went with the second option and also changed "resume" to un(P)ause. 
There is a styling change with the display of the rectangle as well. 
